### PR TITLE
Add httpx to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask
 requests
 uvicorn
 
+httpx


### PR DESCRIPTION
## Summary
- include `httpx` in the dependency list so the client script runs correctly

## Testing
- `python -m py_compile client.py`

------
https://chatgpt.com/codex/tasks/task_b_686c7e770a048325bb387397d7b649a8