### PR TITLE
Add currency conversion unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Codex
+
+## Running Tests
+
+Install the dependencies listed in `requirements.txt` and run:
+
+```bash
+pytest
+```
+
+This executes the test suite located in the `tests` directory.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pydantic>=2.11.4
 flask
 requests
 uvicorn
+pytest>=8.0.0

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,29 @@
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from agents.helloworld.agent_executor import HelloWorldAgentExecutor
+
+class DummyQueue:
+    def __init__(self):
+        self.events = []
+    def enqueue_event(self, event):
+        self.events.append(event)
+
+class DummyInput:
+    def __init__(self, text: str):
+        self.content = text.encode('utf-8')
+
+class DummyContext:
+    def __init__(self, text: str):
+        self.input = DummyInput(text)
+
+def test_convert_currency_usd_to_brl():
+    executor = HelloWorldAgentExecutor()
+    queue = DummyQueue()
+    ctx = DummyContext("convert 25 USD to BRL")
+    import asyncio
+    asyncio.run(executor.convert_currency(ctx, queue))
+    assert queue.events, "No event enqueued"
+    text = queue.events[0].parts[0].root.text
+    assert "USD é equivalente" in text


### PR DESCRIPTION
## Summary
- create basic README with testing instructions
- make `agents` a package and configure pytest
- ensure `pytest` is part of requirements
- add a unit test for currency conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c8d94ed2c8325a2e99d32a04fceb5