### PR TITLE
Add docstrings to client and executors

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,3 +1,5 @@
+"""Entry point that launches the demo agent server using Uvicorn."""
+
 import uvicorn
 from a2a.server.apps import A2AStarletteApplication
 from a2a.server.request_handlers import DefaultRequestHandler

--- a/agent_executor.py
+++ b/agent_executor.py
@@ -2,8 +2,12 @@ from a2a.executor import AgentExecutor
 from a2a.types import AgentSkillInvoke, AgentSkillOutput, MediaTypes
 
 class HelloWorldAgentExecutor(AgentExecutor):
+    """Simple executor exposing a couple of demo skills."""
+
     async def hello_world(self, skill_invoke: AgentSkillInvoke) -> AgentSkillOutput:
+        """Return a plain ``Hello World`` response."""
         return AgentSkillOutput(output=MediaTypes.TEXT_PLAIN.create_content("Hello World"))
 
     async def super_hello_world(self, skill_invoke: AgentSkillInvoke) -> AgentSkillOutput:
+        """Return an enthusiastic ``Hello World`` response."""
         return AgentSkillOutput(output=MediaTypes.TEXT_PLAIN.create_content("Hello World"))

--- a/agents/helloworld/agent_executor.py
+++ b/agents/helloworld/agent_executor.py
@@ -5,15 +5,20 @@ import httpx
 import re
 
 class HelloWorldAgentExecutor(AgentExecutor):
+    """Agent executor providing several demonstration skills."""
+
     async def hello_world(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Send a simple ``Hello World`` message."""
         event_queue.enqueue_event(new_agent_text_message("Hello World"))
 
     async def super_hello_world(
         self, context: RequestContext, event_queue: EventQueue
     ) -> None:
+        """Send an enthusiastic ``Hello World`` greeting."""
         event_queue.enqueue_event(new_agent_text_message("Hello World"))
 
     async def convert_currency(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Parse the user's request and simulate a currency conversion."""
         # Extrair o texto da invocação
         input_text = context.input.content.decode("utf-8")
 
@@ -58,6 +63,7 @@ class HelloWorldAgentExecutor(AgentExecutor):
             ))
 
     async def find_and_greet_agent(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Locate other agents using MCP and greet them."""
         from .mcp import client as mcp_client
         from a2a.client import A2AClient
 
@@ -75,11 +81,11 @@ class HelloWorldAgentExecutor(AgentExecutor):
                 event_queue.enqueue_event(new_agent_text_message(f"Agent {agent.name} responded: {response}"))
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        # Implementação básica para o método execute
+        """Placeholder implementation for running a skill task."""
         pass
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
-        # Implementação básica para o método cancel
+        """Placeholder implementation for cancelling a running task."""
         pass
 
 

--- a/client.py
+++ b/client.py
@@ -14,6 +14,13 @@ from a2a.types import (
 
 
 async def main() -> None:
+    """Run a sample A2A client against the locally running agent server.
+
+    The function resolves the agent card, initializes an :class:`A2AClient`,
+    and demonstrates two skill invocations: ``convert_currency`` and
+    ``super_hello_world``.
+    """
+
     PUBLIC_AGENT_CARD_PATH = '/.well-known/agent.json'
     EXTENDED_AGENT_CARD_PATH = '/agent/authenticatedExtendedCard'
 


### PR DESCRIPTION
## Summary
- document client example's `main` method
- add docstrings to HelloWorldAgentExecutor classes
- add a small module-level description for `__main__.py`

## Testing
- `python -m py_compile __main__.py agent_executor.py agents/helloworld/agent_executor.py client.py`


------
https://chatgpt.com/codex/tasks/task_b_686c8d92fff083258f2848ba857d7536