### PR TITLE
Add missing import for HelloWorld MCP server

### DIFF
--- a/agents/helloworld/mcp/server.py
+++ b/agents/helloworld/mcp/server.py
@@ -1,3 +1,6 @@
+from a2a_mcp.mcp.server import serve
+
+
 def main():
     import argparse
 


### PR DESCRIPTION
## Summary
- add `serve` import to `agents/helloworld/mcp/server.py`

## Testing
- `python -m py_compile agents/helloworld/mcp/server.py`
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_b_686c8d8d9dc083259a8c0533b73602de