### PR TITLE
Fix requirements newline and pin libs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ networkx>=3.4.2
 numpy>=2.2.5
 pandas>=2.2.3
 pydantic>=2.11.4
-flask
-requests
-uvicorn
+flask>=3.1.1
+requests>=2.32.4
+uvicorn>=0.35.0


### PR DESCRIPTION
## Summary
- add missing newline to `requirements.txt`
- pin versions for `flask`, `requests`, and `uvicorn`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_686c8d8790008325a43da1c10296e260